### PR TITLE
FW-359 FOTA Circular Buffer

### DIFF
--- a/projects/fota/inc/hardware/network_buffer.h
+++ b/projects/fota/inc/hardware/network_buffer.h
@@ -1,15 +1,35 @@
 #pragma once
+
+/************************************************************************************************
+ * @file   network_buffer.h
+ *
+ * @brief  Circular Buffer class implementation for firmware over the air (FOTA) updates
+ *
+ * @date   2025-03-16
+ * @author Midnight Sun Team #24 - MSXVI
+ ************************************************************************************************/
+
+
+/* Standard library Headers */
 #include <stdint.h>
 #include <stdbool.h>
 
-#define MAX_PACKETS 8 //TODO: Figure out what this size is
+/* Inter-component Headers */
+
+/* Intra-component Headers */
+
+/* Constants */
+//subject to change, but these were numbers I got from confluence
+#define MAX_PACKETS 8 
 #define PACKET_BYTES 256
-
-
 
 /**
  * @brief struct containing details of circular buffer
  * 
+ * @param data pointer to internally held data
+ * @param size size of circular buffer
+ * @param insert current insert index
+ * @param head current read index
  */
 typedef struct NetworkBuffer {
     packet *data;
@@ -23,32 +43,29 @@ typedef struct NetworkBuffer {
  * 
  */
 typedef enum returnStatus {
-    SUCCESS,
+    SUCCESS = 0,
     ALREADY_INITALISED,
-    FAILED
+    BUFFER_INACTIVE
 } returnStatus;
 
 
 /**
- * @brief data packet which contains 256 bytes
- * 
+ * @brief data packet
+ * @param data pointer to data bytes
  */
 typedef struct packet {
     uint8_t data[PACKET_BYTES];
 } packet;
 
-static packet data[MAX_PACKETS];
-static NetworkBuffer circular_buffer = {data, MAX_PACKETS, 0, 0 };
 
-static bool init = false;
 
 
 /**
  * @brief Initalizes circular buffer for use, by initalizing assocated structs
  * 
- * @return returnStatus: status of initalization
- */
-returnStatus initCircularBuffer();
+ * @return returnStatus
+*/
+returnStatus network_buffer_init();
 
 /**
  * @brief Insert data packet 
@@ -56,7 +73,7 @@ returnStatus initCircularBuffer();
  * @param data pointer to data packet to insert
  * @return returnStatus 
  */
-returnStatus insertNetworkBuffer(packet *data);
+returnStatus network_buffer_insert(packet *data);
 
 /**
  * @brief 
@@ -64,4 +81,4 @@ returnStatus insertNetworkBuffer(packet *data);
  * @param buf reads packet from circular buffer into a provided buffer
  * @return returnStatus 
  */
-returnStatus readNetworkBuffer(packet *buf);
+returnStatus network_buffer_read(packet *buf);

--- a/projects/fota/inc/hardware/network_buffer.h
+++ b/projects/fota/inc/hardware/network_buffer.h
@@ -45,20 +45,16 @@ typedef struct NetworkBuffer {
 typedef enum returnStatus {
     SUCCESS = 0,
     ALREADY_INITALISED,
-    BUFFER_INACTIVE
+    NOT_INITALIZED
 } returnStatus;
-
 
 /**
  * @brief data packet
  * @param data pointer to data bytes
  */
 typedef struct packet {
-    uint8_t data[PACKET_BYTES];
+    uint8_t internal[PACKET_BYTES];
 } packet;
-
-
-
 
 /**
  * @brief Initalizes circular buffer for use, by initalizing assocated structs

--- a/projects/fota/inc/hardware/network_buffer.h
+++ b/projects/fota/inc/hardware/network_buffer.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#define MAX_PACKETS 8 //TODO: Figure out what this size is
+#define PACKET_BYTES 256
+
+
+
+/**
+ * @brief struct containing details of circular buffer
+ * 
+ */
+typedef struct NetworkBuffer {
+    packet *data;
+    uint32_t size;
+    uint32_t insert;
+    uint32_t head;
+} NetworkBuffer;
+
+/**
+ * @brief List of possbile return statuses for circular buffer
+ * 
+ */
+typedef enum returnStatus {
+    SUCCESS,
+    ALREADY_INITALISED,
+    FAILED
+} returnStatus;
+
+
+/**
+ * @brief data packet which contains 256 bytes
+ * 
+ */
+typedef struct packet {
+    uint8_t data[PACKET_BYTES];
+} packet;
+
+static packet data[MAX_PACKETS];
+static NetworkBuffer circular_buffer = {data, MAX_PACKETS, 0, 0 };
+
+static bool init = false;
+
+
+/**
+ * @brief Initalizes circular buffer for use, by initalizing assocated structs
+ * 
+ * @return returnStatus: status of initalization
+ */
+returnStatus initCircularBuffer();
+
+/**
+ * @brief Insert data packet 
+ * 
+ * @param data pointer to data packet to insert
+ * @return returnStatus 
+ */
+returnStatus insertNetworkBuffer(packet *data);
+
+/**
+ * @brief 
+ * 
+ * @param buf reads packet from circular buffer into a provided buffer
+ * @return returnStatus 
+ */
+returnStatus readNetworkBuffer(packet *buf);

--- a/projects/fota/inc/hardware/network_buffer.h
+++ b/projects/fota/inc/hardware/network_buffer.h
@@ -78,7 +78,7 @@ returnStatus network_buffer_insert(packet *data);
 /**
  * @brief 
  * 
- * @param buf reads packet from circular buffer into a provided buffer
+ * @param buf reads packet from circular buffer into a provided location
  * @return returnStatus 
  */
-returnStatus network_buffer_read(packet *buf);
+returnStatus network_buffer_read(packet *loc);

--- a/projects/fota/src/hardware/network_buffer.c
+++ b/projects/fota/src/hardware/network_buffer.c
@@ -4,22 +4,37 @@ static packet data[MAX_PACKETS];
 static NetworkBuffer circular_buffer;
 static bool init = false;
 
-returnStatus networkBuffer_init() {
+returnStatus network_buffer_init() {
     if (init) 
         return ALREADY_INITALISED;
     
     memset(data, 0, MAX_PACKETS * PACKET_BYTES);
-    circular_buffer.data =data;
+    circular_buffer.data = data;
     circular_buffer.size = MAX_PACKETS;
     circular_buffer.head = 0;
     circular_buffer.insert = 0;
     return SUCCESS;
 }
 
-returnStatus network_buffer_insert(packet *data){
 
+returnStatus network_buffer_insert(packet *data){
+    if (!init)
+        return NOT_INITALIZED;
+    
+    memcpy(data[circular_buffer.insert].internal, data, PACKET_BYTES);
+
+    circular_buffer.insert = (circular_buffer.insert + 1) % circular_buffer.size;
+
+    return SUCCESS;
 }
 
-returnStatus networkBuffer_read(packet *loc){
+returnStatus network_buffer_read(packet *loc){
+    if (!init) 
+        return NOT_INITALIZED;
 
+    memcpy(loc, data[circular_buffer.head].internal, PACKET_BYTES);
+
+    circular_buffer.head = (circular_buffer.head + 1) % circular_buffer.size;
+
+    return SUCCESS;
 }

--- a/projects/fota/src/hardware/network_buffer.c
+++ b/projects/fota/src/hardware/network_buffer.c
@@ -1,0 +1,25 @@
+#include "network_buffer.h"
+
+static packet data[MAX_PACKETS];
+static NetworkBuffer circular_buffer;
+static bool init = false;
+
+returnStatus networkBuffer_init() {
+    if (init) 
+        return ALREADY_INITALISED;
+    
+    memset(data, 0, MAX_PACKETS * PACKET_BYTES);
+    circular_buffer.data =data;
+    circular_buffer.size = MAX_PACKETS;
+    circular_buffer.head = 0;
+    circular_buffer.insert = 0;
+    return SUCCESS;
+}
+
+returnStatus network_buffer_insert(packet *data){
+
+}
+
+returnStatus networkBuffer_read(packet *loc){
+
+}


### PR DESCRIPTION
Implements  circular buffer class for firmware over the air. Three main functions, used to interface with circ buffer:
1. network_buffer_init
2. network_buffer_read
3. network_buffer_insert
