### PR TITLE
FOTA Client Validation - Packet Generation

### DIFF
--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -8,15 +8,8 @@
 import serial
 from crc32 import CRC32
 
-# Frame markers
-SOF = 0xAA
-EOF = 0xBB
-
 # Endianness for byte conversion
-BYTEORDER = 'little'  # TODO: Assumed from can_datagram, so confirm
-
-# Size limit for payload
-MAX_PAYLOAD_BYTES = 64  # TODO: Confirm
+BYTE_ORDER = 'little'  # TODO: Assumed from can_datagram, so confirm
 
 crc32 = CRC32(STANDARD_CRC32_POLY)
 
@@ -24,31 +17,51 @@ class FotaPacket():
     """
     @brief Defines serialized format of FOTA packet 
     """
+    SOF = 0xAA
+    EOF = 0xBB
+    MAX_PAYLOAD_BYTES = 64  # TODO: Placeholder, so confirm
 
     def __init__(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
         """Initialize FotaPacket class"""
+
+        # Validate byte sizes
+        if not (0 <= packet_type <= 0xFF):
+            raise ValueError("packet_type must be a single byte")
+        
+        if not (0 <= sequence_num <= 0xFF):
+            raise ValueError("sequence_num must be a single byte")
+        
+        if not (0 <= datagram_id <= 0xFFFFFFFF):
+            raise ValueError("datagram_id must fit in 4 bytes")
+        
+        if len(payload) > FotaPacket.MAX_PAYLOAD_BYTES:
+            raise ValueError("payload too long")
+
         self.sof = FotaPacket.SOF
         self.packet_type = packet_type
         self.datagram_id = datagram_id
         self.sequence_num = sequence_num
         self.payload = payload
         self.payload_len = len(payload)
-        self.crc32 = crc32.calculate(payload)
+        self.crc32_value = crc32.calculate(payload)
         self.eof = FotaPacket.EOF
 
-    def serialize(self) -> bytearray:
+    def pack(self) -> bytearray:
+        """Serialize packet values"""
         packet = bytearray()
 
         packet.append(self.sof)
         packet.append(self.packet_type)
-        packet += self.datagram_id.to_bytes(4, byteorder='little')  # Assumed little endian from can_datagram
+        packet += self.datagram_id.to_bytes(4, BYTE_ORDER)
         packet.append(self.sequence_num)
-        packet += self.payload_len.to_bytes(2, byteorder='little')
+        packet += self.payload_len.to_bytes(2, BYTE_ORDER)
         packet += self.payload
-        packet += self.crc32.to_bytes(4, byteorder='little')
+        packet += self.crc32_value.to_bytes(4, BYTE_ORDER)
         packet.append(self.eof)
 
         return packet
+
+
 
 
 

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -128,7 +128,65 @@ class FotaPacket():
         return self._eof
     
     # Setters
+    @sof.setter
+    def sof(self, value):
+        """
+        @brief Set start-of-frame
+        """
+        self._sof = value
     
+    @packet_type.setter
+    def packet_type(self, value):
+        """
+        @brief Set packet type
+        """
+        assert (0 <= value <= 0xFF)
+        self._packet_type = value
+    
+    @datagram_id.setter
+    def datagram_id(self, value):
+        """
+        @brief Set datagram ID
+        """
+        assert(0 <= value <= 0xFFFFFFFF)
+        self._datagram_id = value
+    
+    @sequence_num.setter
+    def sequence_num(self, value):
+        """
+        @brief Set sequence number
+        """
+        assert(0 <= value <= 0x07)
+        self._sequence_num = value
+    
+    @payload_len.setter
+    def payload_len(self, value):
+        """
+        @brief Set length of payload
+        """
+        assert(len(payload) > FotaPacket.MAX_PAYLOAD_BYTES)
+        self._payload_len = value
+    
+    @payload.setter
+    def payload(self, value):
+        """
+        @brief Set payload
+        """
+        self._payload = value
+    
+    @crc32_value.setter
+    def crc32_value(self, value):
+        """
+        @brief Set CRC32 value
+        """
+        self._payload = value
+    
+    @eof.setter
+    def eof(self, value):
+        """
+        @brief Set end-of-frame
+        """
+        self._eof = value
 
     @staticmethod
     def _check_args(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
@@ -138,11 +196,11 @@ class FotaPacket():
         if not (0 <= packet_type <= 0xFF):
             raise ValueError("packet_type must be a single byte")
         
-        if not (0 <= sequence_num <= 0x07):
-            raise ValueError("sequence_num must be 3 bits")
-        
         if not (0 <= datagram_id <= 0xFFFFFFFF):
             raise ValueError("datagram_id must fit in 4 bytes")
+        
+        if not (0 <= sequence_num <= 0x07):
+            raise ValueError("sequence_num must be 3 bits")
         
         if len(payload) > FotaPacket.MAX_PAYLOAD_BYTES:
             raise ValueError("payload exceeds user-defined limit")

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -61,7 +61,8 @@ class FotaPacket():
 
         return packet
 
-
+    def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
+        return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
 
 

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -23,7 +23,7 @@ class FotaPacket():
     EOF = 0xBB
     MAX_PAYLOAD_BYTES = 64  # TODO: Placeholder, so confirm
 
-    def __init__(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
+    def __init__(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> None:
         """
         @brief Initialize FotaPacket object
         """

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -1,0 +1,12 @@
+## @file    fota_packet_sender.py
+#  @date    2025-05-14
+#  @author  Midnight Sun Team #24 - MSXVI
+#  @brief   Packet class for fota_packet_sender
+#
+#  @ingroup fota_validation
+
+import serial
+
+class FotaPacket():
+    pass
+

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -6,7 +6,38 @@
 #  @ingroup fota_validation
 
 import serial
+from crc32 import CRC32
+
+# Frame markers
+SOF = 0xAA
+EOF = 0xBB
+
+# Endianness for byte conversion
+BYTEORDER = 'little'  # TODO: Assumed from can_datagram, so confirm
+
+# Size limit for payload
+MAX_PAYLOAD_BYTES = 64  # TODO: Confirm
+
+crc32 = CRC32(STANDARD_CRC32_POLY)
 
 class FotaPacket():
-    pass
+    """
+    @brief Defines serialized format of FOTA packet 
+    """
+
+    def __init__(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
+        """Initialize FotaPacket class"""
+        self.sof = FotaPacket.SOF
+        self.packet_type = packet_type
+        self.datagram_id = datagram_id
+        self.sequence_num = sequence_num
+        self.payload = payload
+        self.payload_len = len(payload)
+        self.crc32 = crc32.calculate(payload)
+        self.eof = FotaPacket.EOF
+
+    
+
+
+
 

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -36,7 +36,19 @@ class FotaPacket():
         self.crc32 = crc32.calculate(payload)
         self.eof = FotaPacket.EOF
 
-    
+    def serialize(self) -> bytearray:
+        packet = bytearray()
+
+        packet.append(self.sof)
+        packet.append(self.packet_type)
+        packet += self.datagram_id.to_bytes(4, byteorder='little')  # Assumed little endian from can_datagram
+        packet.append(self.sequence_num)
+        packet += self.payload_len.to_bytes(2, byteorder='little')
+        packet += self.payload
+        packet += self.crc32.to_bytes(4, byteorder='little')
+        packet.append(self.eof)
+
+        return packet
 
 
 

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -128,7 +128,7 @@ class FotaPacket():
         return self._eof
 
     @staticmethod
-    def _check_args(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
+    def _check_args(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> None:
         """
         @brief Validate byte sizes of object parameters
         """

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -118,7 +118,7 @@ class FotaPacket():
         """
         @brief Describe CRC32 value
         """
-        return self._payload
+        return self._crc32_value
     
     @property
     def eof(self):
@@ -128,7 +128,7 @@ class FotaPacket():
         return self._eof
 
     @staticmethod
-    def _check_args(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
+    def _check_args(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
         """
         @brief Validate byte sizes of object parameters
         """

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -44,13 +44,13 @@ class FotaPacket():
         """
         return(
             f"<FotaPacket "
-            f"SOF=0x{self.sof():02X}, "
-            f"Type=0x{self.packet_type():02X}, "
-            f"DatagramID=0x{self.datagram_id():08X}, "
-            f"Seq=0x{self.sequence_num():02X}, "
-            f"Len={self.payload_len()}, "
-            f"CRC32=0x{self.crc32_value():08X}, "
-            f"EOF=0x{self.eof():02X}>"
+            f"SOF=0x{self.sof:02X}, "
+            f"Type=0x{self.packet_type:02X}, "
+            f"DatagramID=0x{self.datagram_id:08X}, "
+            f"Seq=0x{self.sequence_num:02X}, "
+            f"Len={self.payload_len}, "
+            f"CRC32=0x{self.crc32_value:08X}, "
+            f"EOF=0x{self.eof:02X}>"
         )
     
     def pack(self) -> bytearray:
@@ -59,14 +59,14 @@ class FotaPacket():
         """
         packet = bytearray()
 
-        packet.append(self.sof())
-        packet.append(self.packet_type())
-        packet += self.datagram_id().to_bytes(4, BYTE_ORDER)
-        packet.append(self.sequence_num())
-        packet += self.payload_len().to_bytes(2, BYTE_ORDER)
-        packet += self.payload()
-        packet += self.crc32_value().to_bytes(4, BYTE_ORDER)
-        packet.append(self.eof())
+        packet.append(self.sof)
+        packet.append(self.packet_type)
+        packet += self.datagram_id.to_bytes(4, BYTE_ORDER)
+        packet.append(self.sequence_num)
+        packet += self.payload_len.to_bytes(2, BYTE_ORDER)
+        packet += self.payload
+        packet += self.crc32_value.to_bytes(4, BYTE_ORDER)
+        packet.append(self.eof)
 
         return packet
     

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -5,7 +5,7 @@
 #
 #  @ingroup fota_validation
 
-from crc32 import CRC32  # TODO: Resolve import error
+from crc32 import CRC32
 
 # TODO: Stolen from can_datagram/bootloader_id, so check for correct code
 STANDARD_CRC32_POLY = 0x04C11DB7
@@ -27,19 +27,7 @@ class FotaPacket():
         """
         @brief Initialize FotaPacket object
         """
-        # TODO: Move to a private method
-        ## Validate byte sizes
-        if not (0 <= packet_type <= 0xFF):
-            raise ValueError("packet_type must be a single byte")
-        
-        if not (0 <= sequence_num <= 0x07):
-            raise ValueError("sequence_num must be 3 bits")
-        
-        if not (0 <= datagram_id <= 0xFFFFFFFF):
-            raise ValueError("datagram_id must fit in 4 bytes")
-        
-        if len(payload) > FotaPacket.MAX_PAYLOAD_BYTES:
-            raise ValueError("payload exceeds user-defined limit")
+        self._check_args(packet_type, datagram_id, sequence_num, payload)
 
         self.sof = FotaPacket.SOF
         self.packet_type = packet_type
@@ -64,6 +52,22 @@ class FotaPacket():
             f"CRC32=0x{self.crc32_value:08X}, "
             f"EOF=0x{self.eof:02X}>"
         )
+    
+    def _check_args(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
+        """
+        @brief Validate byte sizes of object parameters
+        """
+        if not (0 <= packet_type <= 0xFF):
+            raise ValueError("packet_type must be a single byte")
+        
+        if not (0 <= sequence_num <= 0x07):
+            raise ValueError("sequence_num must be 3 bits")
+        
+        if not (0 <= datagram_id <= 0xFFFFFFFF):
+            raise ValueError("datagram_id must fit in 4 bytes")
+        
+        if len(payload) > FotaPacket.MAX_PAYLOAD_BYTES:
+            raise ValueError("payload exceeds user-defined limit")
 
     def pack(self) -> bytearray:
         """

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -29,14 +29,14 @@ class FotaPacket():
         """
         self._check_args(packet_type, datagram_id, sequence_num, payload)
 
-        self.sof = FotaPacket.SOF
-        self.packet_type = packet_type
-        self.datagram_id = datagram_id
-        self.sequence_num = sequence_num
-        self.payload = payload
-        self.payload_len = len(payload)
-        self.crc32_value = crc32.calculate(payload)
-        self.eof = FotaPacket.EOF
+        self._sof = FotaPacket.SOF
+        self._packet_type = packet_type
+        self._datagram_id = datagram_id
+        self._sequence_num = sequence_num
+        self._payload = payload
+        self._payload_len = len(payload)
+        self._crc32_value = crc32.calculate(payload)
+        self._eof = FotaPacket.EOF
 
     def __repr__(self) -> str:
         """
@@ -44,15 +44,93 @@ class FotaPacket():
         """
         return(
             f"<FotaPacket "
-            f"SOF=0x{self.sof:02X}, "
-            f"Type=0x{self.packet_type:02X}, "
-            f"DatagramID=0x{self.datagram_id:08X}, "
-            f"Seq=0x{self.sequence_num:02X}, "
-            f"Len={self.payload_len}, "
-            f"CRC32=0x{self.crc32_value:08X}, "
-            f"EOF=0x{self.eof:02X}>"
+            f"SOF=0x{self.sof():02X}, "
+            f"Type=0x{self.packet_type():02X}, "
+            f"DatagramID=0x{self.datagram_id():08X}, "
+            f"Seq=0x{self.sequence_num():02X}, "
+            f"Len={self.payload_len()}, "
+            f"CRC32=0x{self.crc32_value():08X}, "
+            f"EOF=0x{self.eof():02X}>"
         )
     
+    def pack(self) -> bytearray:
+        """
+        @brief Serialize packet values for transmission
+        """
+        packet = bytearray()
+
+        packet.append(self.sof())
+        packet.append(self.packet_type())
+        packet += self.datagram_id().to_bytes(4, BYTE_ORDER)
+        packet.append(self.sequence_num())
+        packet += self.payload_len().to_bytes(2, BYTE_ORDER)
+        packet += self.payload()
+        packet += self.crc32_value().to_bytes(4, BYTE_ORDER)
+        packet.append(self.eof())
+
+        return packet
+    
+    # Getters
+    @property
+    def sof(self):
+        """
+        @brief Describe start-of-frame
+        """
+        return self._sof
+    
+    @property
+    def packet_type(self):
+        """
+        @brief Describe packet type
+        """
+        return self._packet_type
+    
+    @property
+    def datagram_id(self):
+        """
+        @brief Describe datagram ID
+        """
+        return self._datagram_id
+    
+    @property
+    def sequence_num(self):
+        """
+        @brief Describe sequence number
+        """
+        return self._sequence_num
+    
+    @property
+    def payload_len(self):
+        """
+        @brief Describe length of payload
+        """
+        return self._payload_len
+    
+    @property
+    def payload(self):
+        """
+        @brief Describe payload
+        """
+        return self._payload
+    
+    @property
+    def crc32_value(self):
+        """
+        @brief Describe CRC32 value
+        """
+        return self._payload
+    
+    @property
+    def eof(self):
+        """
+        @brief Describe end-of-frame
+        """
+        return self._eof
+    
+    # Setters
+    
+
+    @staticmethod
     def _check_args(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
         """
         @brief Validate byte sizes of object parameters
@@ -68,20 +146,3 @@ class FotaPacket():
         
         if len(payload) > FotaPacket.MAX_PAYLOAD_BYTES:
             raise ValueError("payload exceeds user-defined limit")
-
-    def pack(self) -> bytearray:
-        """
-        @brief Serialize packet values for transmission
-        """
-        packet = bytearray()
-
-        packet.append(self.sof)
-        packet.append(self.packet_type)
-        packet += self.datagram_id.to_bytes(4, BYTE_ORDER)
-        packet.append(self.sequence_num)
-        packet += self.payload_len.to_bytes(2, BYTE_ORDER)
-        packet += self.payload
-        packet += self.crc32_value.to_bytes(4, BYTE_ORDER)
-        packet.append(self.eof)
-
-        return packet

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -27,8 +27,8 @@ class FotaPacket():
         """
         @brief Initialize FotaPacket object
         """
-
-        # Validate byte sizes
+        # TODO: Move to a private method
+        ## Validate byte sizes
         if not (0 <= packet_type <= 0xFF):
             raise ValueError("packet_type must be a single byte")
         

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -126,67 +126,6 @@ class FotaPacket():
         @brief Describe end-of-frame
         """
         return self._eof
-    
-    # Setters
-    @sof.setter
-    def sof(self, value):
-        """
-        @brief Set start-of-frame
-        """
-        self._sof = value
-    
-    @packet_type.setter
-    def packet_type(self, value):
-        """
-        @brief Set packet type
-        """
-        assert (0 <= value <= 0xFF)
-        self._packet_type = value
-    
-    @datagram_id.setter
-    def datagram_id(self, value):
-        """
-        @brief Set datagram ID
-        """
-        assert(0 <= value <= 0xFFFFFFFF)
-        self._datagram_id = value
-    
-    @sequence_num.setter
-    def sequence_num(self, value):
-        """
-        @brief Set sequence number
-        """
-        assert(0 <= value <= 0x07)
-        self._sequence_num = value
-    
-    @payload_len.setter
-    def payload_len(self, value):
-        """
-        @brief Set length of payload
-        """
-        assert(len(payload) > FotaPacket.MAX_PAYLOAD_BYTES)
-        self._payload_len = value
-    
-    @payload.setter
-    def payload(self, value):
-        """
-        @brief Set payload
-        """
-        self._payload = value
-    
-    @crc32_value.setter
-    def crc32_value(self, value):
-        """
-        @brief Set CRC32 value
-        """
-        self._payload = value
-    
-    @eof.setter
-    def eof(self, value):
-        """
-        @brief Set end-of-frame
-        """
-        self._eof = value
 
     @staticmethod
     def _check_args(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -5,7 +5,6 @@
 #
 #  @ingroup fota_validation
 
-import serial
 from crc32 import CRC32  # TODO: Resolve import error
 
 # TODO: Stolen from can_datagram/bootloader_id, so check for correct code
@@ -18,7 +17,7 @@ crc32 = CRC32(STANDARD_CRC32_POLY)
 
 class FotaPacket():
     """
-    @brief Defines serialized format of FOTA packet 
+    @brief Defines serialized format of a FOTA packet 
     """
     SOF = 0xAA
     EOF = 0xBB
@@ -26,7 +25,7 @@ class FotaPacket():
 
     def __init__(self, packet_type: int, datagram_id: int, sequence_num: int, payload: bytes):
         """
-        @brief Initialize FotaPacket class
+        @brief Initialize FotaPacket object
         """
 
         # Validate byte sizes
@@ -67,11 +66,6 @@ class FotaPacket():
         packet.append(self.eof)
 
         return packet
-
-    # TODO: Move to fota_packet_sender.py
-    def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
-        """Factory function for fota_packet_sender.py"""
-        return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
 
 

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -52,7 +52,7 @@ class FotaPacket():
 
     def __repr__(self) -> str:
         """
-        @brief 
+        @brief Readable representation of FotaPacket object
         """
         return(
             f"<FotaPacket "
@@ -81,7 +81,3 @@ class FotaPacket():
         packet.append(self.eof)
 
         return packet
-
-
-
-

--- a/py/fota_validation/fota_packet.py
+++ b/py/fota_validation/fota_packet.py
@@ -50,6 +50,21 @@ class FotaPacket():
         self.crc32_value = crc32.calculate(payload)
         self.eof = FotaPacket.EOF
 
+    def __repr__(self) -> str:
+        """
+        @brief 
+        """
+        return(
+            f"<FotaPacket "
+            f"SOF=0x{self.sof:02X}, "
+            f"Type=0x{self.packet_type:02X}, "
+            f"DatagramID=0x{self.datagram_id:08X}, "
+            f"Seq=0x{self.sequence_num:02X}, "
+            f"Len={self.payload_len}, "
+            f"CRC32=0x{self.crc32_value:08X}, "
+            f"EOF=0x{self.eof:02X}>"
+        )
+
     def pack(self) -> bytearray:
         """
         @brief Serialize packet values for transmission

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -28,9 +28,22 @@ class FotaPacketSender():
 
         return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
-    def send_fota_packet(fota_packet: FotaPacket):
+    def send_fota_packet(self, fota_packet: FotaPacket):
         """
         @brief Transmit FotaPacket to XBee
         """
+
+        try:
+            packet_bytes = fota_packet.pack()
+            self.serial_port.write(packet_bytes)
+            self.serial_port.flush()  # Ensure immediate transmission
+
+            print(f"Sent FOTA packet: {fota_packet}")
+
+        except serial.SerialException as e:
+            print(f"Serial error during transmission: {e}")
+        
+        except Exception as e:
+            print(f"Unexpected error during transmission: {e}")
 
         pass

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -21,6 +21,14 @@ class FotaPacketSender():
 
         self.ser = serial.Serial(port = port, baudrate = baudrate, timeout = timeout)
 
+    def __del__(self):
+        """
+        @brief Close serial connection when object is deleted or program exits
+        """
+
+        self.close()
+
+    @staticmethod
     def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
         """
         @brief Factory for FotaPacket objects

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -13,19 +13,16 @@ class FotaPacketSender():
     """
     @brief Accessed by DatagramSender to transmit FotaPackets via XBees
     """
-
     def __init__(self, port: str, baudrate: int = 115200, timeout: float = 1) -> None:
         """
         @brief Initialize FotaPacketSender with a serial connection
         """
-
         self.ser = serial.Serial(port = port, baudrate = baudrate, timeout = timeout)
 
     def __del__(self):
         """
         @brief Close serial connection when object is deleted or program exits
         """
-
         self.close()
 
     @staticmethod
@@ -33,14 +30,12 @@ class FotaPacketSender():
         """
         @brief Factory for FotaPacket objects
         """
-
         return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
     def send_fota_packet(self, fota_packet: FotaPacket) -> None:
         """
         @brief Transmit FotaPacket to XBee
         """
-
         try:
             packet_bytes = fota_packet.pack()
             self.ser.write(packet_bytes)
@@ -58,7 +53,6 @@ class FotaPacketSender():
         """
         @brief Close serial connection
         """
-
         if self.ser.is_open:
             self.ser.close()
             print(f"\nConnection to port {self.ser.port} closed!\n")

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -1,0 +1,17 @@
+## @file    fota_packet_sender.py
+#  @date    2025-05-14
+#  @author  Midnight Sun Team #24 - MSXVI
+#  @brief   Packet sender class for fota_datagram_sender
+#
+#  @ingroup fota_validation
+
+import serial
+
+from fota_packet import FotaPacket
+
+class FotaPacketSender():
+    def create_fota_packet(datagram_id, packet_type, sequence_num, payload):
+        pass
+
+    def send_fota_packet(fota_packet: FotaPacket):
+        pass

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -14,6 +14,13 @@ class FotaPacketSender():
     @brief Accessed by DatagramSender to transmit FotaPackets via XBees
     """
 
+    def __init__(self, port: str, baudrate: int = 115200, timeout: float = 1):
+        """
+        @brief Initialize FotaPacketSender with a serial connection
+        """
+
+        self.serial_port = serial.Serial(port = port, baudrate = baudrate, timeout = timeout)
+
     def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
         """
         @brief Factory for FotaPacket objects
@@ -25,4 +32,5 @@ class FotaPacketSender():
         """
         @brief Transmit FotaPacket to XBee
         """
+
         pass

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -26,13 +26,13 @@ class FotaPacketSender():
         self.close()
 
     @staticmethod
-    def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
+    def create(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
         """
         @brief Factory for FotaPacket objects
         """
         return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
-    def send_fota_packet(self, fota_packet: FotaPacket) -> None:
+    def send(self, fota_packet: FotaPacket) -> None:
         """
         @brief Transmit FotaPacket to XBee
         """

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -10,8 +10,19 @@ import serial
 from fota_packet import FotaPacket
 
 class FotaPacketSender():
-    def create_fota_packet(datagram_id, packet_type, sequence_num, payload):
-        pass
+    """
+    @brief Accessed by DatagramSender to transmit FotaPackets via XBees
+    """
+
+    def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
+        """
+        @brief Factory for FotaPacket objects
+        """
+
+        return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
     def send_fota_packet(fota_packet: FotaPacket):
+        """
+        @brief Transmit FotaPacket to XBee
+        """
         pass

--- a/py/fota_validation/fota_packet_sender.py
+++ b/py/fota_validation/fota_packet_sender.py
@@ -14,12 +14,12 @@ class FotaPacketSender():
     @brief Accessed by DatagramSender to transmit FotaPackets via XBees
     """
 
-    def __init__(self, port: str, baudrate: int = 115200, timeout: float = 1):
+    def __init__(self, port: str, baudrate: int = 115200, timeout: float = 1) -> None:
         """
         @brief Initialize FotaPacketSender with a serial connection
         """
 
-        self.serial_port = serial.Serial(port = port, baudrate = baudrate, timeout = timeout)
+        self.ser = serial.Serial(port = port, baudrate = baudrate, timeout = timeout)
 
     def create_fota_packet(packet_type: int, datagram_id: int, sequence_num: int, payload: bytes) -> FotaPacket:
         """
@@ -28,15 +28,15 @@ class FotaPacketSender():
 
         return FotaPacket(packet_type, datagram_id, sequence_num, payload)
 
-    def send_fota_packet(self, fota_packet: FotaPacket):
+    def send_fota_packet(self, fota_packet: FotaPacket) -> None:
         """
         @brief Transmit FotaPacket to XBee
         """
 
         try:
             packet_bytes = fota_packet.pack()
-            self.serial_port.write(packet_bytes)
-            self.serial_port.flush()  # Ensure immediate transmission
+            self.ser.write(packet_bytes)
+            self.ser.flush()  # Ensure immediate transmission
 
             print(f"Sent FOTA packet: {fota_packet}")
 
@@ -46,4 +46,11 @@ class FotaPacketSender():
         except Exception as e:
             print(f"Unexpected error during transmission: {e}")
 
-        pass
+    def close(self) -> None:
+        """
+        @brief Close serial connection
+        """
+
+        if self.ser.is_open:
+            self.ser.close()
+            print(f"\nConnection to port {self.ser.port} closed!\n")

--- a/py/fota_validation/fota_validation.py
+++ b/py/fota_validation/fota_validation.py
@@ -6,3 +6,4 @@
 #  @details
 #
 #  @ingroup fota_validation
+


### PR DESCRIPTION
## Overview
- Created `FotaPacket` and `FotaPacketSender` classes to support the FOTA datagrams

## Notes/Questions
- Tried to reference `can_datagram.py` as much as possible, but didn't follow the `**kwargs`-style parameters (along with the use of `assert`) and used type hints instead--_is this okay?_
- Wrote setters, but didn't know if they were necessary, so I removed them--_are these packets supposed to be immutable?_
- `fota_packet_sender.py` definitely doesn't have as much checks in place compared to `can_datagram.py`'s sender, or _will the eventual `FotaDatagramSender` have even more to do with ensuring successful comms?_
- For future reference, how do I make sure my code passes the lint and formatter?
- All in all, please let me know what to add/improve🙏