### PR TITLE
Fix compile_commands.json generation.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -131,7 +131,7 @@ if COMMAND == "mpxe":
 # Retrieve the construction environment from the appropriate platform script
 env = SConscript(f'platform/{PLATFORM}.py', exports=['HARDWARE_TYPE', 'FLASH_TYPE', 'BUILD_CONFIG'])
 
-database_name = f"compile_commands_{PLATFORM}.json"
+database_name = f"compile_commands.json"
 config = scons_compiledb.Config(db=database_name)
 scons_compiledb.enable_with_cmdline(env, config)
 


### PR DESCRIPTION
Generate compile_db without target specificity, because clangd only uses compile_commands.json or .compile_commands.json.