### PR TITLE
make build faster/correct scons num_jobs logic

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -91,8 +91,8 @@ AddOption(
 
 NUM_JOBS = os.cpu_count() or 4
 
-if not GetOption("num_jobs"):
-    AddOption("--jobs", dest="num_jobs", type="int", default=NUM_JOBS)
+if GetOption("num_jobs") == 1:
+    SetOption("num_jobs", NUM_JOBS)
 
 PLATFORM = GetOption("platform")
 TARGET = GetOption("name")


### PR DESCRIPTION
`GetOption("num_jobs")` defaults to 1 and never returns 0 so this logic didn't work. on my laptop `scons --project=steering` after `scons clean --project=steering` (with no -j given) goes from 1m11s to 6s. despite removing `--jobs` this is a builtin and still works, unless you specify `-j1`, but I cannot imagine anyone would want that.