### PR TITLE
Telemetry Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# gitignore
+.gitignore
+
 # build directory
 build/*
 venv/*
@@ -53,3 +56,7 @@ mpxe/Simulation_JSON/*
 
 # LVGL
 libraries/lvgl9/src/
+
+# Claude
+CLAUDE.md
+.claude/

--- a/autogen/templates/project_can/src/{{project_name}}_rx_all.c.jinja
+++ b/autogen/templates/project_can/src/{{project_name}}_rx_all.c.jinja
@@ -28,9 +28,6 @@ CanWatchDog s_{{message.name}}_msg_watchdog = {0, {{message.receiver[project_nam
 void can_rx_all() {
     CanMessage msg = { 0 };
     while (can_receive(&msg) == STATUS_CODE_OK) {
-        // if (IS_EXCLUDED_WS22_CAN_ID(msg.id.raw)){
-        //     continue;
-        // }
 
         /* TODO: Not sure if loop is best way */
         /* Might be O(n) */

--- a/libraries/ms-common/inc/global_enums.h
+++ b/libraries/ms-common/inc/global_enums.h
@@ -124,10 +124,6 @@ typedef enum {
 /** @brief  Temperature limit flag mask */
 #define LIMIT_FLAG_TEMPERATURE_MASK (1U << LIMIT_FLAG_TEMPERATURE)
 
-/** @brief  IDs of WS22 CAN messages to exclude from telemetry datagram forwarding */
-// #define IS_EXCLUDED_WS22_CAN_ID(x) ((((x) >= 128U) && ((x) <= 142U)) || ((x) == 151U) || ((x) == 1281U))
-#define IS_EXCLUDED_WS22_CAN_ID(x) ((x == 1281U))
-
 /************************************************************************************************
  * Front Controller Global Definitions
  ************************************************************************************************/
@@ -243,6 +239,13 @@ typedef enum {
 #define STEERING_CC_DECREASE_MASK (1U << EE_STEERING_CC_DECREASE_BIT)
 /** @brief  Toggle cruise control mask */
 #define STEERING_CC_TOGGLE_MASK (1U << EE_STEERING_CC_TOGGLE_BIT)
+
+/************************************************************************************************
+ * WS22 Motor Controller Global Definitions
+ ************************************************************************************************/
+
+/** @brief  True for any raw CAN ID belonging to the WS22 motor controller (status 0x81-0x8B or drive cmd 0x501). */
+#define IS_WS22_CAN_ID(x) (((x) >= 0x80U && (x) <= 0x8BU) || (x) == 0x501U)
 
 /************************************************************************************************
  * Power Distribution Global Definitions

--- a/libraries/ms-common/inc/global_enums.h
+++ b/libraries/ms-common/inc/global_enums.h
@@ -125,7 +125,8 @@ typedef enum {
 #define LIMIT_FLAG_TEMPERATURE_MASK (1U << LIMIT_FLAG_TEMPERATURE)
 
 /** @brief  IDs of WS22 CAN messages to exclude from telemetry datagram forwarding */
-#define IS_EXCLUDED_WS22_CAN_ID(x) ((((x) >= 128U) && ((x) <= 142U)) || ((x) == 151U) || ((x) == 1281U))
+// #define IS_EXCLUDED_WS22_CAN_ID(x) ((((x) >= 128U) && ((x) <= 142U)) || ((x) == 151U) || ((x) == 1281U))
+#define IS_EXCLUDED_WS22_CAN_ID(x) ((x == 1281U))
 
 /************************************************************************************************
  * Front Controller Global Definitions

--- a/libraries/ms-drivers/inc/ws22_motor_can.h
+++ b/libraries/ms-drivers/inc/ws22_motor_can.h
@@ -101,6 +101,7 @@ typedef struct {
   bool ws22_motor_back_emf_enabled;       /**< Flag to indicate if CAN reading motor_back_emf is enabled */
   bool ws22_rail_15v_enabled;             /**< Flag to indicate if CAN reading rail_15v is enabled */
   bool ws22_temperature_enabled;          /**< Flag to indicate if CAN reading temperature is enabled */
+  bool ws22_drive_cmd_enabled;            /**< Flag to enable parsing of drive command (0x501); disabled by default */
 } Ws22MotorCanConfig;
 
 /**

--- a/libraries/ms-drivers/src/ws22_motor_can.c
+++ b/libraries/ms-drivers/src/ws22_motor_can.c
@@ -110,6 +110,17 @@ static StatusCode s_process_rail_15v(Ws22MotorTelemetryData *telemetry, uint8_t 
   return STATUS_CODE_OK;
 }
 
+static StatusCode s_process_drive_cmd(Ws22MotorControlData *control, uint8_t *msg_data_u8, uint8_t msg_dlc) {
+  if (control == NULL || msg_data_u8 == NULL || msg_dlc < 8U) {
+    return STATUS_CODE_INVALID_ARGS;
+  }
+
+  memcpy(&control->current, &msg_data_u8[0], sizeof(float));
+  memcpy(&control->velocity, &msg_data_u8[4], sizeof(float));
+
+  return STATUS_CODE_OK;
+}
+
 static StatusCode s_process_temperature(Ws22MotorTelemetryData *telemetry, uint8_t *msg_data_u8, uint8_t msg_dlc) {
   if (telemetry == NULL || msg_data_u8 == NULL || msg_dlc < 8U) {
     return STATUS_CODE_INVALID_ARGS;
@@ -209,6 +220,12 @@ StatusCode ws22_motor_can_process_rx(uint8_t *msg_data_u8, uint32_t msg_id_raw, 
         return STATUS_CODE_OK;
       }
       return s_process_temperature(&s_ws22_motor_can_storage->telemetry, msg_data_u8, msg_dlc);
+
+    case WS22_CAN_ID_DRIVE_CMD:
+      if (!s_ws22_motor_can_config->ws22_drive_cmd_enabled) {
+        return STATUS_CODE_OK;
+      }
+      return s_process_drive_cmd(&s_ws22_motor_can_storage->control, msg_data_u8, msg_dlc);
 
     default:
       return STATUS_CODE_UNIMPLEMENTED;

--- a/projects/front_controller/src/main.c
+++ b/projects/front_controller/src/main.c
@@ -51,6 +51,7 @@ Ws22MotorCanConfig motor_can_config = {
   .ws22_motor_back_emf_enabled = true,
   .ws22_rail_15v_enabled = true,
   .ws22_temperature_enabled = true,
+  .ws22_drive_cmd_enabled = false,
 };
 
 VehicleDriveState drive_state;

--- a/projects/rear_controller/src/main.c
+++ b/projects/rear_controller/src/main.c
@@ -48,6 +48,7 @@ Ws22MotorCanConfig motor_can_config = {
   .ws22_motor_back_emf_enabled = false,
   .ws22_rail_15v_enabled = false,
   .ws22_temperature_enabled = false,
+  .ws22_drive_cmd_enabled = false,
 };
 
 void pre_loop_init() {}

--- a/projects/rear_controller/src/precharge.c
+++ b/projects/rear_controller/src/precharge.c
@@ -24,7 +24,7 @@
 #define PRECHARGE_MODE_COMPARE 1U
 #define PRECHARGE_MODE_TIMEOUT 2U
 
-#define PRECHARGE_MODE PRECHARGE_MODE_TIMEOUT
+#define PRECHARGE_MODE PRECHARGE_MODE_COMPARE
 
 #define PRECHARGE_DEBUG 0U
 
@@ -82,6 +82,11 @@ StatusCode precharge_init(Event event, const Task *task, RearControllerStorage *
   rear_controller_storage = storage;
   set_rear_controller_status_triggers_motor_precharge_complete(false);
   valid_cycles = 0;
+#endif
+
+#if (PRECHARGE_MODE == PRECHARGE_MODE_TIMEOUT)
+  rear_controller_storage = storage;
+  rear_controller_storage->precharge_complete = false;
 #endif
 
   return STATUS_CODE_OK;

--- a/projects/steering/src/main.c
+++ b/projects/steering/src/main.c
@@ -45,6 +45,7 @@ Ws22MotorCanConfig motor_can_config = {
   .ws22_motor_back_emf_enabled = false,
   .ws22_rail_15v_enabled = false,
   .ws22_temperature_enabled = true,
+  .ws22_drive_cmd_enabled = false,
 };
 
 void pre_loop_init() {}

--- a/projects/telemetry/config.json
+++ b/projects/telemetry/config.json
@@ -3,7 +3,8 @@
         "FreeRTOS",
         "ms-common",
         "master",
-        "FATFs"
+        "FATFs",
+        "ms-drivers"
     ],
     "x86_libs": [
         "ms-mpxe"

--- a/projects/telemetry/inc/can_cache.h
+++ b/projects/telemetry/inc/can_cache.h
@@ -1,0 +1,85 @@
+#pragma once
+
+/************************************************************************************************
+ * @file   can_cache.h
+ *
+ * @brief  CAN message cache for telemetry round-robin transmission
+ *
+ * @date   2026-06-10
+ * @author Midnight Sun Team #24 - MSXVI
+ ************************************************************************************************/
+
+/* Standard library Headers */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup telemetry
+ * @brief    telemetry Firmware
+ * @{
+ */
+
+/** @brief  Synthetic XBee-only ID for the telemetry bus-load stats datagram (device=4, msg_id=62). */
+#define TELEMETRY_STATS_CAN_ID 2020U
+/** @brief  DLC of the telemetry stats datagram (3 × uint16_t). */
+#define TELEMETRY_STATS_DLC 6U
+
+/** @brief  Synthetic XBee-only IDs for WS22 re-encoded telemetry (floats → scaled integers). */
+#define WS22_TELEMETRY_STATUS_ID    2034U /**< error_flags (u16) + limit_flags (u16) */
+#define WS22_TELEMETRY_BUS_ID       2035U /**< bus_voltage_cV (u16) + bus_current_cA (i16) */
+#define WS22_TELEMETRY_VELOCITY_ID  2036U /**< motor_velocity_rpm×10 (i16) + vehicle_kph×100 (u16) */
+#define WS22_TELEMETRY_TEMP_ID      2037U /**< motor_temp_°C×10 (i16) + heatsink_temp_°C×10 (i16) */
+#define WS22_TELEMETRY_DRIVE_CMD_ID 2038U /**< drive_current×10000 (u16) + drive_velocity_rpm (i16) */
+#define WS22_TELEMETRY_DLC          4U    /**< DLC for all WS22 synthetic entries (2 × uint16_t) */
+
+/**
+ * @brief   Transmission priority tier for a cached CAN message
+ * @details Derived from the message's cycle rate in the board YAML:
+ *          fast-cycle → HIGH, medium-cycle → MEDIUM, slow-cycle → LOW
+ */
+typedef enum {
+  CAN_MSG_PRIORITY_HIGH = 0,
+  CAN_MSG_PRIORITY_MEDIUM,
+  CAN_MSG_PRIORITY_LOW,
+  NUM_CAN_MSG_PRIORITIES,
+} CanMsgPriority;
+
+/**
+ * @brief   Per-message cache entry
+ * @details One entry exists for every CAN message that targets the telemetry board.
+ *          Task A populates data and sets pending; Task B drains pending entries and transmits.
+ */
+typedef struct {
+  uint32_t can_id;              /**< Raw 11-bit CAN bus ID used to match incoming messages */
+  uint8_t length;               /**< DLC: number of valid data bytes */
+  uint8_t data[8];              /**< Cached payload */
+  CanMsgPriority priority;      /**< Priority tier this entry belongs to */
+  bool pending;                 /**< True when data has been updated but not yet transmitted */
+  uint32_t last_updated_tick;   /**< Tick count when this entry last received a CAN message; 0 = never */
+  uint32_t last_tx_tick;        /**< Tick count when this entry was last transmitted; 0 = never */
+  uint32_t tx_cooldown_ticks;   /**< Minimum ticks between TX; 0 = no rate limit */
+} CanMessageCache;
+
+/**
+ * @brief   High-priority (fast-cycle) message cache
+ * @details Currently empty — no fast-cycle messages target telemetry.
+ */
+extern CanMessageCache g_can_cache_high[];
+extern const size_t g_can_cache_high_size;
+
+/**
+ * @brief   Medium-priority (medium-cycle) message cache
+ * @details Contains 22 entries from rear_controller, steering, front_controller, and IMU.
+ */
+extern CanMessageCache g_can_cache_medium[];
+extern const size_t g_can_cache_medium_size;
+
+/**
+ * @brief   Low-priority (slow-cycle) message cache
+ * @details Contains 3 entries from front_controller power group messages.
+ */
+extern CanMessageCache g_can_cache_low[];
+extern const size_t g_can_cache_low_size;
+
+/** @} */

--- a/projects/telemetry/inc/datagram.h
+++ b/projects/telemetry/inc/datagram.h
@@ -58,6 +58,15 @@ typedef struct {
 StatusCode decode_can_message(Datagram *datagram, CanMessage *msg);
 
 /**
+ * @brief   Encode id/dlc/data directly into a datagram (no CanMessage wrapper).
+ * @param   datagram Pointer to the datagram to populate
+ * @param   id       Raw CAN ID
+ * @param   dlc      Payload length in bytes
+ * @param   data     Pointer to payload
+ */
+StatusCode encode_datagram(Datagram *datagram, uint32_t id, uint8_t dlc, const uint8_t *data);
+
+/**
  * @brief   Log the decoded datagram for debug purposes
  * @param   datagram Pointer to the datagram to be debugged
  */

--- a/projects/telemetry/inc/telemetry.h
+++ b/projects/telemetry/inc/telemetry.h
@@ -13,6 +13,7 @@
 
 /* Inter-component Headers */
 #include "queue.h"
+#include "ws22_motor_can.h"
 
 /* Intra-component Headers */
 #include "bmi323.h"
@@ -44,6 +45,7 @@ typedef struct {
   Queue datagram_queue;                           /**< Queue handle for the datagram buffer */
   Bmi323Storage *bmi323_storage;                  /**< Pointer to BMI323 storage struct */
   CanStorage *can_storage;                        /**< Pointer to CAN storage struct, to be used in xb_transmit */
+  Ws22MotorCanStorage *ws22_storage;              /**< Pointer to WS22 parsed data; populated before telemetry_init */
   TelemetryConfig *config;                        /**< Pointer to the telemetry configuration data */
 } TelemetryStorage;
 

--- a/projects/telemetry/src/can_cache.c
+++ b/projects/telemetry/src/can_cache.c
@@ -1,0 +1,77 @@
+/************************************************************************************************
+ * @file    can_cache.c
+ *
+ * @brief   Static CAN message cache definitions for telemetry
+ *
+ * @date    2026-06-10
+ * @author  Midnight Sun Team #24 - MSXVI
+ ************************************************************************************************/
+
+/* Standard library Headers */
+#include <stddef.h>
+
+/* Inter-component Headers */
+
+/* Intra-component Headers */
+#include "can_cache.h"
+
+/* CAN IDs come from can/tools/system_dbc.dbc. Priority tier is the message cycle rate
+   in the source board's YAML (fast→HIGH, medium→MEDIUM, slow→LOW). */
+
+/* No fast-cycle messages target telemetry — placeholder keeps the array valid. */
+CanMessageCache g_can_cache_high[] = {
+  { 0 },
+};
+const size_t g_can_cache_high_size = 0U;
+
+CanMessageCache g_can_cache_medium[] = {
+  /* rear_controller messages */
+  { .can_id = 17U, .length = 4U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* rear_controller_status */
+  { .can_id = 33U, .length = 6U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* battery_stats_A        */
+  { .can_id = 49U, .length = 6U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* battery_stats_B        */
+  { .can_id = 65U, .length = 8U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* power_input_stats      */
+  /* steering */
+  { .can_id = 96U, .length = 5U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* steering               */
+  /* front_controller */
+  { .can_id = 1365U, .length = 5U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* drive_status           */
+  /* imu */
+  { .can_id = 1827U, .length = 6U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* accel_data             */
+  { .can_id = 1843U, .length = 6U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* gyro_data              */
+  /* WS22 motor CAN messages are excluded: payloads are raw IEEE 754 floats whose bytes
+     can be 0xAA/0xBB, corrupting datagram framing. WS22 data must be pre-processed
+     through ws22_motor_can_process_rx and re-encoded as scaled integers before adding here. */
+  /* rear_controller AFE messages */
+  { .can_id = 1825U, .length = 8U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE_discharge_bitset   */
+  { .can_id = 1841U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_A          */
+  { .can_id = 1857U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_B          */
+  { .can_id = 1873U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_C          */
+  { .can_id = 1889U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_D          */
+  { .can_id = 1905U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_E          */
+  { .can_id = 1921U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE1_status_F          */
+  { .can_id = 1937U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_A          */
+  { .can_id = 1953U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_B          */
+  { .can_id = 1969U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_C          */
+  { .can_id = 1985U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_D          */
+  { .can_id = 2001U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_E          */
+  { .can_id = 2017U, .length = 7U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE2_status_F          */
+  { .can_id = 2033U, .length = 8U, .priority = CAN_MSG_PRIORITY_MEDIUM }, /* AFE_temperature        */
+};
+const size_t g_can_cache_medium_size = sizeof(g_can_cache_medium) / sizeof(g_can_cache_medium[0]);
+
+CanMessageCache g_can_cache_low[] = {
+  /* ---- CAN-received slow-cycle messages ---- */
+  { .can_id = 1525U, .length = 8U, .priority = CAN_MSG_PRIORITY_LOW }, /* fc_power_group_A      */
+  { .can_id = 1573U, .length = 8U, .priority = CAN_MSG_PRIORITY_LOW }, /* fc_power_lights_group */
+  { .can_id = 1621U, .length = 4U, .priority = CAN_MSG_PRIORITY_LOW }, /* fc_power_group_B      */
+
+  /* ---- Telemetry-internal messages (populated by scheduler, not CAN RX) ---- */
+  { .can_id = TELEMETRY_STATS_CAN_ID,    .length = TELEMETRY_STATS_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* telemetry_stats       */
+
+  /* ---- WS22 synthetic messages (floats re-encoded as scaled integers) ---- */
+  { .can_id = WS22_TELEMETRY_STATUS_ID,    .length = WS22_TELEMETRY_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* ws22_status    */
+  { .can_id = WS22_TELEMETRY_BUS_ID,       .length = WS22_TELEMETRY_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* ws22_bus       */
+  { .can_id = WS22_TELEMETRY_VELOCITY_ID,  .length = WS22_TELEMETRY_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* ws22_velocity  */
+  { .can_id = WS22_TELEMETRY_TEMP_ID,      .length = WS22_TELEMETRY_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* ws22_temp      */
+  { .can_id = WS22_TELEMETRY_DRIVE_CMD_ID, .length = WS22_TELEMETRY_DLC, .priority = CAN_MSG_PRIORITY_LOW }, /* ws22_drive_cmd */
+};
+const size_t g_can_cache_low_size = sizeof(g_can_cache_low) / sizeof(g_can_cache_low[0]);

--- a/projects/telemetry/src/datagram.c
+++ b/projects/telemetry/src/datagram.c
@@ -26,10 +26,6 @@ StatusCode decode_can_message(Datagram *datagram, CanMessage *msg) {
   datagram->start_frame = DATAGRAM_START_FRAME;
   datagram->id = FLIP_ENDIANESS_2BYTES(msg->id.raw);
 
-  if (IS_EXCLUDED_WS22_CAN_ID(msg->id.raw)) {
-    return STATUS_CODE_INVALID_ARGS;
-  }
-
   datagram->dlc = msg->dlc;
 
   for (size_t i = 0; i < msg->dlc; ++i) {
@@ -38,6 +34,17 @@ StatusCode decode_can_message(Datagram *datagram, CanMessage *msg) {
 
   datagram->data[datagram->dlc] = DATAGRAM_END_FRAME;
 
+  return STATUS_CODE_OK;
+}
+
+StatusCode encode_datagram(Datagram *datagram, uint32_t id, uint8_t dlc, const uint8_t *data) {
+  datagram->start_frame = DATAGRAM_START_FRAME;
+  datagram->id = FLIP_ENDIANESS_2BYTES(id);
+  datagram->dlc = dlc;
+  for (size_t i = 0; i < dlc; ++i) {
+    datagram->data[i] = data[i];
+  }
+  datagram->data[dlc] = DATAGRAM_END_FRAME;
   return STATUS_CODE_OK;
 }
 

--- a/projects/telemetry/src/main.c
+++ b/projects/telemetry/src/main.c
@@ -18,6 +18,7 @@
 #include "mcu.h"
 #include "tasks.h"
 #include "uart.h"
+#include "ws22_motor_can.h"
 
 /* Intra-component Headers */
 #include "imu.h"
@@ -62,6 +63,20 @@ Bmi323Storage bmi323_storage = {
 
 CanStorage can_storage = { 0 };
 
+Ws22MotorCanStorage ws22_storage = { 0 };
+Ws22MotorCanConfig ws22_config = {
+  .ws22_status_info_enabled = true,
+  .ws22_bus_measurement_enabled = true,
+  .ws22_velocity_measurement_enabled = true,
+  .ws22_phase_current_enabled = false,
+  .ws22_motor_voltage_enabled = false,
+  .ws22_motor_current_enabled = false,
+  .ws22_motor_back_emf_enabled = false,
+  .ws22_rail_15v_enabled = false,
+  .ws22_temperature_enabled = true,
+  .ws22_drive_cmd_enabled = true,
+};
+
 float roll = 0;
 float pitch = 0;
 float yaw = 0;
@@ -94,6 +109,8 @@ int main() {
   tasks_init();
   log_init();
 
+  ws22_motor_can_init(&ws22_storage, &ws22_config);
+  telemetry_storage.ws22_storage = &ws22_storage;
   telemetry_init(&telemetry_storage, &telemetry_config, &bmi323_storage, &can_storage);
   init_master_tasks();
 

--- a/projects/telemetry/src/xb_transmit.c
+++ b/projects/telemetry/src/xb_transmit.c
@@ -8,6 +8,7 @@
  ************************************************************************************************/
 
 /* Standard library Headers */
+#include <string.h>
 
 /* Inter-component Headers */
 #include "can.h"
@@ -17,33 +18,290 @@
 #include "uart.h"
 
 /* Intra-component Headers */
+#include "can_cache.h"
 #include "datagram.h"
 #include "telemetry.h"
+#include "ws22_motor_can.h"
 #include "xb_transmit.h"
-
-#define XB_TRANSMIT_DEBUG 0U
 
 static TelemetryStorage *s_telemetry_storage = NULL;
 
-TASK(can_message_forwarder, TASK_STACK_512) {
-  size_t datagram_length = 0U;
-  Datagram tx_datagram = { 0U };
-  CanMessage message = { 0U };
-#if (XB_TRANSMIT_DEBUG != 0)
-  StatusCode status = STATUS_CODE_OK;
-#endif
+static size_t s_sched_idx[NUM_CAN_MSG_PRIORITIES];
 
-  while (true) {
-    /* Wait for new data to be in the queue */
-    while (queue_receive(&s_telemetry_storage->can_storage->rx_queue.queue, &message, QUEUE_DELAY_BLOCKING) != STATUS_CODE_OK) {
+/* Written by Task A, snapshot+reset by Task B every second. */
+static volatile uint32_t s_can_rx_count = 0U;
+
+/* Task B only — no cross-task sync needed. */
+static uint32_t s_xbee_tx_count = 0U;
+static uint32_t s_xbee_bytes_sent = 0U;
+
+#define FC_RECENTLY_WRITTEN_MS 5000U
+#define TELEMETRY_STATS_INTERVAL_MS 1000U
+#define WS22_UPDATE_INTERVAL_MS 500U
+#define XBEE_MAX_BYTES_PER_SEC (230400U / 10U) /* 8N1: 10 bits per byte */
+
+typedef struct {
+  uint32_t can_id;
+  const char *name;
+} FcMsgName;
+
+static const FcMsgName s_fc_names[] = {
+  { 1365U, "drive_status" },
+  { 1525U, "fc_power_group_A" },
+  { 1573U, "fc_power_lights_group" },
+  { 1621U, "fc_power_group_B" },
+};
+
+/* Sends next pending entry from tier; returns bytes transmitted, 0 if none pending.
+   Entries with tx_cooldown_ticks > 0 are skipped until the cooldown has elapsed. */
+static size_t s_try_send_from_tier(CanMessageCache *cache, size_t size, size_t *start_idx) {
+  if (size == 0U) {
+    return 0U;
+  }
+
+  uint32_t now = (uint32_t)xTaskGetTickCount();
+
+  for (size_t checked = 0U; checked < size; checked++) {
+    size_t i = (*start_idx + checked) % size;
+
+    bool was_pending = false;
+    uint32_t saved_id = 0U;
+    uint8_t saved_dlc = 0U;
+    uint8_t saved_data[8] = { 0 };
+
+    taskENTER_CRITICAL();
+    if (cache[i].pending) {
+      if (cache[i].tx_cooldown_ticks > 0U && (now - cache[i].last_tx_tick) < cache[i].tx_cooldown_ticks) {
+        taskEXIT_CRITICAL();
+        continue; /* cooldown not elapsed — skip, leave pending */
+      }
+      was_pending = true;
+      saved_id = cache[i].can_id;
+      saved_dlc = cache[i].length;
+      memcpy(saved_data, cache[i].data, sizeof(saved_data));
+      cache[i].pending = false;
+      cache[i].last_tx_tick = now;
     }
+    taskEXIT_CRITICAL();
 
-    if (decode_can_message(&tx_datagram, &message) == STATUS_CODE_OK) {
-      datagram_length = tx_datagram.dlc + DATAGRAM_METADATA_SIZE;
-      uart_tx(UART_PORT_2, (uint8_t *)&tx_datagram, datagram_length);
+    if (was_pending) {
+      *start_idx = (i + 1U) % size;
+      Datagram tx_datagram = { 0 };
+      if (encode_datagram(&tx_datagram, saved_id, saved_dlc, saved_data) == STATUS_CODE_OK) {
+        size_t datagram_length = saved_dlc + DATAGRAM_METADATA_SIZE;
+        uart_tx(s_telemetry_storage->config->uart_port, (uint8_t *)&tx_datagram, datagram_length);
+        return datagram_length;
+      }
+    }
+  }
+  return 0U;
+}
+
+static void s_update_ws22_entry(uint32_t can_id, const uint8_t *data) {
+  for (size_t i = 0U; i < g_can_cache_low_size; i++) {
+    if (g_can_cache_low[i].can_id == can_id) {
+      taskENTER_CRITICAL();
+      memcpy(g_can_cache_low[i].data, data, WS22_TELEMETRY_DLC);
+      g_can_cache_low[i].pending = true;
+      taskEXIT_CRITICAL();
+      return;
     }
   }
 }
+
+static void s_update_ws22_cache(void) {
+  Ws22MotorTelemetryData *tel = ws22_motor_can_get_telemetry_data();
+  Ws22MotorControlData *ctrl = ws22_motor_can_get_control_data();
+  uint8_t buf[WS22_TELEMETRY_DLC];
+  uint16_t val;
+
+  /* Status: error_flags (u16) | limit_flags (u16) */
+  val = tel->error_flags;
+  buf[0] = (uint8_t)(val & 0xFFU);
+  buf[1] = (uint8_t)(val >> 8U);
+  val = tel->limit_flags;
+  buf[2] = (uint8_t)(val & 0xFFU);
+  buf[3] = (uint8_t)(val >> 8U);
+  s_update_ws22_entry(WS22_TELEMETRY_STATUS_ID, buf);
+
+  /* Bus: voltage in centivolt (u16) | current in centiamp (i16) */
+  val = (uint16_t)(tel->bus_voltage * 100.0f);
+  buf[0] = (uint8_t)(val & 0xFFU);
+  buf[1] = (uint8_t)(val >> 8U);
+  val = (uint16_t)((int16_t)(tel->bus_current * 100.0f));
+  buf[2] = (uint8_t)(val & 0xFFU);
+  buf[3] = (uint8_t)(val >> 8U);
+  s_update_ws22_entry(WS22_TELEMETRY_BUS_ID, buf);
+
+  /* Velocity: motor_velocity rpm×10 (i16) | vehicle_velocity kph×100 (u16) */
+  val = (uint16_t)((int16_t)(tel->motor_velocity * 10.0f));
+  buf[0] = (uint8_t)(val & 0xFFU);
+  buf[1] = (uint8_t)(val >> 8U);
+  val = (uint16_t)(tel->vehicle_velocity_kph * 100.0f);
+  buf[2] = (uint8_t)(val & 0xFFU);
+  buf[3] = (uint8_t)(val >> 8U);
+  s_update_ws22_entry(WS22_TELEMETRY_VELOCITY_ID, buf);
+
+  /* Temperature: motor_temp °C×10 (i16) | heatsink_temp °C×10 (i16) */
+  val = (uint16_t)((int16_t)(tel->motor_temp * 10.0f));
+  buf[0] = (uint8_t)(val & 0xFFU);
+  buf[1] = (uint8_t)(val >> 8U);
+  val = (uint16_t)((int16_t)(tel->heat_sink_temp * 10.0f));
+  buf[2] = (uint8_t)(val & 0xFFU);
+  buf[3] = (uint8_t)(val >> 8U);
+  s_update_ws22_entry(WS22_TELEMETRY_TEMP_ID, buf);
+
+  /* Drive command: current×10000 (u16) | velocity_rpm (i16) */
+  val = (uint16_t)(ctrl->current * 10000.0f);
+  buf[0] = (uint8_t)(val & 0xFFU);
+  buf[1] = (uint8_t)(val >> 8U);
+  val = (uint16_t)((int16_t)ctrl->velocity);
+  buf[2] = (uint8_t)(val & 0xFFU);
+  buf[3] = (uint8_t)(val >> 8U);
+  s_update_ws22_entry(WS22_TELEMETRY_DRIVE_CMD_ID, buf);
+}
+
+static void s_update_stats_cache(uint16_t can_rx_rate, uint16_t xbee_tx_rate, uint8_t xbee_load_pct) {
+  uint8_t stats[TELEMETRY_STATS_DLC];
+  stats[0] = (uint8_t)(can_rx_rate & 0xFFU);
+  stats[1] = (uint8_t)(can_rx_rate >> 8U);
+  stats[2] = (uint8_t)(xbee_tx_rate & 0xFFU);
+  stats[3] = (uint8_t)(xbee_tx_rate >> 8U);
+  stats[4] = xbee_load_pct;
+  stats[5] = 0U;
+
+  size_t low_size = g_can_cache_low_size;
+  for (size_t i = 0U; i < low_size; i++) {
+    if (g_can_cache_low[i].can_id == TELEMETRY_STATS_CAN_ID) {
+      taskENTER_CRITICAL();
+      memcpy(g_can_cache_low[i].data, stats, TELEMETRY_STATS_DLC);
+      g_can_cache_low[i].pending = true;
+      taskEXIT_CRITICAL();
+      break;
+    }
+  }
+}
+
+/* Task A: drains CAN RX queue into the message cache. */
+TASK(can_cache_updater, TASK_STACK_512) {
+  CanMessageCache *caches[] = { g_can_cache_high, g_can_cache_medium, g_can_cache_low };
+  const size_t sizes[] = { g_can_cache_high_size, g_can_cache_medium_size, g_can_cache_low_size };
+  CanMessage message = { 0 };
+
+  while (true) {
+    while (queue_receive(&s_telemetry_storage->can_storage->rx_queue.queue, &message, QUEUE_DELAY_BLOCKING) != STATUS_CODE_OK) {
+    }
+
+    taskENTER_CRITICAL();
+    s_can_rx_count++;
+    taskEXIT_CRITICAL();
+
+    bool is_ws22 = IS_WS22_CAN_ID(message.id.raw);
+
+    if (is_ws22) {
+      ws22_motor_can_process_rx(message.data_u8, message.id.raw, 8U);
+    } else {
+      for (int p = 0; p < NUM_CAN_MSG_PRIORITIES; p++) {
+        bool matched = false;
+        for (size_t i = 0U; i < sizes[p]; i++) {
+          if (caches[p][i].can_id == message.id.raw) {
+            taskENTER_CRITICAL();
+            caches[p][i].last_updated_tick = (uint32_t)xTaskGetTickCount();
+            if (!caches[p][i].pending) {
+              memcpy(caches[p][i].data, message.data_u8, sizeof(caches[p][i].data));
+              caches[p][i].pending = true;
+            }
+            taskEXIT_CRITICAL();
+            matched = true;
+            break;
+          }
+        }
+
+        if (matched) {
+          break;
+        }
+      }
+    }
+  }
+}
+
+/* Task B: round-robin HIGH→MEDIUM→LOW scheduler; updates bus-load stats cache every second. */
+TASK(can_cache_scheduler, TASK_STACK_512) {
+  CanMessageCache *caches[] = { g_can_cache_high, g_can_cache_medium, g_can_cache_low };
+  const size_t sizes[] = { g_can_cache_high_size, g_can_cache_medium_size, g_can_cache_low_size };
+  uint32_t last_stats_tick = (uint32_t)xTaskGetTickCount();
+  uint32_t last_ws22_tick = (uint32_t)xTaskGetTickCount();
+
+  while (true) {
+    for (int p = 0; p < NUM_CAN_MSG_PRIORITIES; p++) {
+      size_t bytes = s_try_send_from_tier(caches[p], sizes[p], &s_sched_idx[p]);
+      if (bytes > 0U) {
+        s_xbee_tx_count++;
+        s_xbee_bytes_sent += (uint32_t)bytes;
+        break;
+      }
+    }
+
+    uint32_t now = (uint32_t)xTaskGetTickCount();
+    if ((now - last_stats_tick) >= TELEMETRY_STATS_INTERVAL_MS) {
+      uint32_t rx_snapshot;
+      taskENTER_CRITICAL();
+      rx_snapshot = s_can_rx_count;
+      s_can_rx_count = 0U;
+      taskEXIT_CRITICAL();
+
+      uint8_t load_pct = (uint8_t)((s_xbee_bytes_sent * 100U) / XBEE_MAX_BYTES_PER_SEC);
+      s_update_stats_cache((uint16_t)rx_snapshot, (uint16_t)s_xbee_tx_count, load_pct);
+      s_xbee_tx_count = 0U;
+      s_xbee_bytes_sent = 0U;
+      last_stats_tick = now;
+    }
+
+    if ((now - last_ws22_tick) >= WS22_UPDATE_INTERVAL_MS) {
+      s_update_ws22_cache();
+      last_ws22_tick = now;
+    }
+
+    /* 1ms gap prevents HAL semaphore desync at 230400 baud. */
+    vTaskDelay(pdMS_TO_TICKS(1));
+  }
+}
+
+#ifdef LOG_DEBUG_SUMMARY
+/* Task C: logs front_controller cache state once per second (debug only). */
+TASK(can_cache_summary, TASK_STACK_512) {
+  CanMessageCache *caches[] = { g_can_cache_high, g_can_cache_medium, g_can_cache_low };
+  const size_t sizes[] = { g_can_cache_high_size, g_can_cache_medium_size, g_can_cache_low_size };
+  static const char *prio_str[] = { "HIGH  ", "MEDIUM", "LOW   " };
+
+  while (true) {
+    vTaskDelay(pdMS_TO_TICKS(1000));
+    uint32_t now = (uint32_t)xTaskGetTickCount();
+    LOG_DEBUG("=== front_controller CAN cache ===\r\n");
+    for (size_t m = 0; m < sizeof(s_fc_names) / sizeof(s_fc_names[0]); m++) {
+      for (int p = 0; p < NUM_CAN_MSG_PRIORITIES; p++) {
+        for (size_t i = 0; i < sizes[p]; i++) {
+          if (caches[p][i].can_id != s_fc_names[m].can_id) continue;
+          bool pending;
+          uint32_t last_tick;
+          taskENTER_CRITICAL();
+          pending = caches[p][i].pending;
+          last_tick = caches[p][i].last_updated_tick;
+          taskEXIT_CRITICAL();
+          if (last_tick == 0U) {
+            LOG_DEBUG("  %-24s ID=%-4lu [%s] new=%c last=never\r\n", s_fc_names[m].name, (unsigned long)s_fc_names[m].can_id, prio_str[p], pending ? 'Y' : 'N');
+          } else {
+            uint32_t elapsed = now - last_tick;
+            LOG_DEBUG("  %-24s ID=%-4lu [%s] new=%c last=%lums [%s]\r\n", s_fc_names[m].name, (unsigned long)s_fc_names[m].can_id, prio_str[p], pending ? 'Y' : 'N', (unsigned long)elapsed,
+                      elapsed < FC_RECENTLY_WRITTEN_MS ? "recent" : "stale");
+          }
+        }
+      }
+    }
+    LOG_DEBUG("==================================\r\n");
+  }
+}
+#endif
 
 StatusCode xb_transmit_init(TelemetryStorage *storage, TelemetryConfig *config) {
   if (storage == NULL || config == NULL) {
@@ -52,7 +310,11 @@ StatusCode xb_transmit_init(TelemetryStorage *storage, TelemetryConfig *config) 
 
   s_telemetry_storage = storage;
   s_telemetry_storage->config = config;
-  tasks_init_task(can_message_forwarder, TASK_PRIORITY(2), NULL);
+  tasks_init_task(can_cache_updater, TASK_PRIORITY(2), NULL);
+  tasks_init_task(can_cache_scheduler, TASK_PRIORITY(2), NULL);
+#ifdef LOG_DEBUG_SUMMARY
+  tasks_init_task(can_cache_summary, TASK_PRIORITY(1), NULL);
+#endif
 
   return STATUS_CODE_OK;
 }

--- a/projects/telemetry/src/xb_transmit.c
+++ b/projects/telemetry/src/xb_transmit.c
@@ -11,6 +11,7 @@
 
 /* Inter-component Headers */
 #include "can.h"
+#include "global_enums.h"
 #include "log.h"
 #include "tasks.h"
 #include "uart.h"
@@ -37,21 +38,9 @@ TASK(can_message_forwarder, TASK_STACK_512) {
     while (queue_receive(&s_telemetry_storage->can_storage->rx_queue.queue, &message, QUEUE_DELAY_BLOCKING) != STATUS_CODE_OK) {
     }
 
-#if (XB_TRANSMIT_DEBUG != 0)
-    LOG_DEBUG("Received message\r\n");
-#endif
     if (decode_can_message(&tx_datagram, &message) == STATUS_CODE_OK) {
       datagram_length = tx_datagram.dlc + DATAGRAM_METADATA_SIZE;
-#if (XB_TRANSMIT_DEBUG == 0)
       uart_tx(UART_PORT_2, (uint8_t *)&tx_datagram, datagram_length);
-#else
-      status = uart_tx(UART_PORT_2, (uint8_t *)&tx_datagram, datagram_length);
-      if (status != STATUS_CODE_OK) {
-        LOG_DEBUG("Failed to transmit to telemetry transceiver!\r\n");
-      } else {
-        LOG_DEBUG("Transmitted message\r\n");
-      }
-#endif
     }
   }
 }

--- a/smoke/rear/rc_state_manager/config.json
+++ b/smoke/rear/rc_state_manager/config.json
@@ -19,7 +19,9 @@
         "projects/rear_controller/src/precharge.o",
         "projects/rear_controller/src/rear_controller.o",
         "projects/rear_controller/src/rear_controller_state_manager.o",
-        "projects/rear_controller/src/relays.o"
+        "projects/rear_controller/src/relays.o",
+        "projects/rear_controller/src/motor_can.o",
+        "projects/rear_controller/src/cell_sense.o"
     ],
     "can": true,
     "selected_preset": "STM32L496RGT6_legacy_debug"

--- a/smoke/rear/rc_state_manager/src/main.c
+++ b/smoke/rear/rc_state_manager/src/main.c
@@ -61,9 +61,10 @@ static InterruptSettings killswitch_settings = {
   INTERRUPT_EDGE_FALLING,
 };
 
+static Ws22MotorCanStorage s_motor_can_storage = { 0 };
 static RearControllerStorage s_rear_storage;
 static RearControllerConfig s_rear_config = { 0 };
-
+static Ws22MotorCanConfig s_ws22_motor_can_config = { 0 };
 static const char *print_state_str(RearControllerState state) {
   switch (state) {
     case REAR_CONTROLLER_STATE_IDLE:
@@ -89,7 +90,8 @@ static void log_status(void) {
 TASK(rear_controller_smoke, TASK_STACK_1024) {
   LOG_DEBUG("Initializing the rear controller...\n");
   s_rear_storage.config = &s_rear_config;
-  rear_controller_init(&s_rear_storage, &s_rear_config);
+  s_rear_storage.ws22_motor_can_storage = &s_motor_can_storage;
+  rear_controller_init(&s_rear_storage, &s_rear_config, &s_ws22_motor_can_config);
   delay_ms(100U);
   gpio_init_pin(&killswitch_address, GPIO_INPUT_PULL_UP, GPIO_STATE_HIGH);
 


### PR DESCRIPTION
New telemetry backend, round-robin priority based can message caching & sending. Telemetry generates its own messages (XBee & CAN bus load) and transmits. Telemetry has a ws22 CAN message parser and transmits CAN messages.